### PR TITLE
Add error handling on lookup of user info

### DIFF
--- a/radosgw_usage_exporter.py
+++ b/radosgw_usage_exporter.py
@@ -462,6 +462,11 @@ class RADOSGWCollector(object):
         )
         logging.debug((json.dumps(user_info, indent=4, sort_keys=True)))
 
+        if user_info is None:
+            logging.warning(f"Failed to get info for user: {user}. "
+                            "Metrics for this user will not be added.")
+            return
+
         if "display_name" in user_info:
             user_display_name = user_info["display_name"]
         else:


### PR DESCRIPTION
Without this, the exporter would hang after rasing the error:

```
  File "radosgw_usage_exporter.py", line 465, in _get_user_info
    if "display_name" in user_info:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```