### PR TITLE
Fix azimuth-cloud actions org

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -31,7 +31,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push image
-        uses: stackhpc/github-actions/docker-multiarch-build-push@master
+        uses: azimuth-images/github-actions/docker-multiarch-build-push@master
         with:
           cache-key: radosgw_usage_exporter
           context: .


### PR DESCRIPTION
stackhpc/github-actions was migrated to azimuth-cloud. Fix this so it doens't confuse pinning actions.