### PR TITLE
Fix incorrect org for action

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -31,7 +31,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push image
-        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@master
+        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@8771cb1c1db134e99becf314f07db6a84b8d7fbf
         with:
           cache-key: radosgw_usage_exporter
           context: .

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -31,7 +31,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push image
-        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@8771cb1c1db134e99becf314f07db6a84b8d7fbf
+        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@master
         with:
           cache-key: radosgw_usage_exporter
           context: .

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -31,7 +31,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push image
-        uses: azimuth-images/github-actions/docker-multiarch-build-push@master
+        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@master
         with:
           cache-key: radosgw_usage_exporter
           context: .


### PR DESCRIPTION
https://github.com/stackhpc/radosgw_usage_exporter/pull/5 was incorrect, meant to move action from stackhpc to azimuth-cloud.
Also update to what's currently pinned.